### PR TITLE
Update: Make everything public

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,4 +1,0 @@
-{
-  "builds": [{ "src": "public/*", "use": "@now/static" }],
-  "routes": [{ "src": "/(.*)", "dest": "/public/$1" }]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "public": true
+}


### PR DESCRIPTION
You can just use [this configuration](https://vercel.com/docs/configuration#project/public) to make everything in `/public` publicly accessible.

Some context:
- `Now` is now called `Vercel`. Therefore, I'm changing `now.json` to `vercel.json`. It's only a meaningless name change.
- `Vercel` is a young product which is evolving quickly. So the configuration you have is a bit outdated.